### PR TITLE
check for non-empty shortMsg

### DIFF
--- a/hooks/post-receive.bugsweb
+++ b/hooks/post-receive.bugsweb
@@ -49,11 +49,13 @@ foreach ($rpath as $commit) {
     $commitMsg  = trim($matches[3]);
     $bugNumber  = $matches[6];
     $shortMsg   = trim($matches[7]);
-    if ($shortMsg[0] == '(') {
-        $shortMsg = substr($shortMsg, 1);
-    }
-    if ($shortMsg[strlen($shortMsg)-1] == ')') {
-        $shortMsg = substr($shortMsg, 0, -1);
+    if (strlen($shortMsg) > 0) {
+        if ($shortMsg[0] == '(') {
+            $shortMsg = substr($shortMsg, 1);
+        }
+        if ($shortMsg[strlen($shortMsg)-1] == ')') {
+            $shortMsg = substr($shortMsg, 0, -1);
+        }
     }
 
     $output = sprintf(


### PR DESCRIPTION
The $shortMsg value can be an empty string when the bug number is the last thing in the commit log line: e.g. "[user@php.net] 0df3233344 Fixed bug #1234"

This variable is not currently used anywhere, so we could probably remove it entirely. But for the moment, let's just fix the Notices being printed.
