### PR TITLE
protect master branches except for the pecl repos against force pushes

### DIFF
--- a/hooks/pre-receive
+++ b/hooks/pre-receive
@@ -25,8 +25,9 @@ include 'Git/PreReceiveHook.php';
 
 $weKnowWhatWeAreDoing = ['dsp', 'johannes', 'tyrael'];
 // On restricted branches forced pushes are only possible by users listed in $weKnowWhatWeAreDoing
+// the master branch is always protected except for the pecl/ repos, see below
 $restrictedBranches =
-    ['php-src.git' => ['refs/heads/PHP-5.4', 'refs/heads/PHP-5.3', 'refs/heads/PHP-5.5', 'refs/heads/PHP-5.6', 'refs/heads/master'],
+    ['php-src.git' => ['refs/heads/PHP-5.4', 'refs/heads/PHP-5.3', 'refs/heads/PHP-5.5', 'refs/heads/PHP-5.6'],
      'playground.git' => ['refs/heads/dsp']];
 // On closed branches only RMs may push
 $closedBranches = [
@@ -153,8 +154,11 @@ if (isset($closedBranches[$repo_name])) {
 }
 
 $restricted = [];
+if (strpos($repo_name, 'pecl/') !== 0  && in_array('refs/heads/master', $pi->getBranches())) {
+	$restricted[] = 'refs/heads/master';
+}
 if (isset($restrictedBranches[$repo_name])) {
-    $restricted = array_filter($restrictedBranches[$repo_name],
+    $restricted += array_filter($restrictedBranches[$repo_name],
         function ($branch) use ($pi) {
             return in_array($branch, $pi->getBranches());
         });


### PR DESCRIPTION
as discussed on the mailing list it would be nice if not everybody can force push for every other repo but php-src.git.
@johannes mentioned that we should allow force pushes for the pecl repos so what I came up with is to restrict force pushes by default for the master branch on every repo except those with a name starting with pecl/.
I tried to test my changes, but testing a pre-receive hooks is a PITA manually, so it would be nice if somebody could review my change before merging it.